### PR TITLE
fix "stat: illegal option -- c"

### DIFF
--- a/conf.d/sdk.fish
+++ b/conf.d/sdk.fish
@@ -15,11 +15,11 @@ if not test -f "$__fish_sdkman_init"
     exit 0
 end
 
-# Hack for issue #19: 
+# Hack for issue #19:
 # Create version of sdkman-init that doesn't export any environment variables.
 # Refresh if sdkman-init changed.
 if  begin    not test -f "$__fish_sdkman_noexport_init";
-          or     env test "$__fish_sdkman_init" -nt "$__fish_sdkman_noexport_init" 
+          or     env test "$__fish_sdkman_init" -nt "$__fish_sdkman_noexport_init"
     end
     mkdir -p (dirname $__fish_sdkman_noexport_init)
     sed -e 's/^\(\s*\).*\(export\|to_path\).*$/\1:/g' "$__fish_sdkman_init" \
@@ -31,15 +31,15 @@ end
 # Returns the same status code as the given command.
 function __fish_sdkman_run_in_bash
     # We need to leave stdin and stdout of sdk free for user interaction.
-    # So, pipe relevant environment variables (which might have changed) 
+    # So, pipe relevant environment variables (which might have changed)
     # through a file.
     # But since now getting the exit code of sdk itself is a hassle,
     # pipe it as well.
     #
     # TODO: Can somebody get this to work without the overhead of a file?
     set pipe (mktemp)
-    bash -c "$argv[1]; 
-             echo -e \"\$?\" > $pipe; 
+    bash -c "$argv[1];
+             echo -e \"\$?\" > $pipe;
              env | grep -e '^SDKMAN_\|^PATH' >> $pipe;
              env | grep -i -E \"^(`echo \${SDKMAN_CANDIDATES_CSV} | sed 's/,/|/g'`)_HOME\" >> $pipe;
              echo \"SDKMAN_OFFLINE_MODE=\${SDKMAN_OFFLINE_MODE}\" >> $pipe" # it's not an environment variable!
@@ -48,14 +48,14 @@ function __fish_sdkman_run_in_bash
     set sdkStatus $bashDump[1]
     set bashEnv $bashDump[2..-1]
 
-    # If SDKMAN! succeeded, copy relevant environment variables 
+    # If SDKMAN! succeeded, copy relevant environment variables
     # to the current shell (they might have changed)
     if [ $sdkStatus = 0 ]
         for line in $bashEnv
             set parts (string split "=" $line)
             set var $parts[1]
             set value (string join "=" $parts[2..-1])
-            
+
             switch "$var"
             case "PATH"
                 # Special treatment: need fish list instead
@@ -74,10 +74,10 @@ function __fish_sdkman_run_in_bash
     return $sdkStatus
 end
 
-# If this is a subshell of a(n initialized) fish owned by the same user, 
-# no initialization necessary. 
+# If this is a subshell of a(n initialized) fish owned by the same user,
+# no initialization necessary.
 # Otherwise:
-if not set -q SDKMAN_DIR; or test (stat -c "%U" $SDKMAN_DIR) != (whoami)
+if not set -q SDKMAN_DIR; or test (stat -f "%Su" $SDKMAN_DIR) != (whoami)
     __fish_sdkman_run_in_bash "source $__fish_sdkman_init"
 end
 


### PR DESCRIPTION
@reitzig 

Hi, I am getting the issue with stat -c in MacOS 10.14.6. 
stat -c does not work normally
```
stat: illegal option -- c
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
```

See https://github.com/phpbrew/phpbrew/issues/399