### PR TITLE
Delete forcefully temp file for bashDump

### DIFF
--- a/conf.d/sdk.fish
+++ b/conf.d/sdk.fish
@@ -43,7 +43,7 @@ function __fish_sdkman_run_in_bash
              env | grep -e '^SDKMAN_\|^PATH' >> $pipe;
              env | grep -i -E \"^(`echo \${SDKMAN_CANDIDATES_CSV} | sed 's/,/|/g'`)_HOME\" >> $pipe;
              echo \"SDKMAN_OFFLINE_MODE=\${SDKMAN_OFFLINE_MODE}\" >> $pipe" # it's not an environment variable!
-    set bashDump (cat $pipe; rm $pipe)
+    set bashDump (cat $pipe; rm -f $pipe)
 
     set sdkStatus $bashDump[1]
     set bashEnv $bashDump[2..-1]


### PR DESCRIPTION
If the user sets alias `alias rm "rm -i"` to be protective about delete files, it will prompt every time we run `sdk` command. It's better to just forcefully delete the temp file.

<img width="1281" alt="Screenshot 2023-06-20 at 3 39 20 PM" src="https://github.com/reitzig/sdkman-for-fish/assets/159186/ae25b5be-ba22-4621-88e6-7265a3644495">
