### PR TITLE
fix: Respect globally set `SDKMAN_DIR`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Warn on bad custom install path 
+
 ### Fixes
 
+- Respect `SDKMAN_DIR` if already set (#52; thanks, @xtexChooser!)
 - Completions use custom SDKMAN! install path (#48; thanks, @Bryan2333!)
 
 ## [2.0.0] - 2023-06-27

--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ _Note:_
 
  - Only compatible with fisher v4 upwards; v3 is no longer supported.
  - You have to install [SDKMAN!] separately.
- - If you have installed SDKMAN! at a custom location, you need to add
-   ```fish
-   set -g __sdkman_custom_dir /your/path/to/sdkman
-   ```
-   to a fish config file
-     [run _before_](https://fishshell.com/docs/current/language.html#configuration-files)
-   `.config/fish/conf.d/sdk.fish`;
-   for example, you can use `.config/fish/conf.d/config_sdk.fish`.
+ - If you have installed SDKMAN! at a custom location, you need to either
+   - set environment variable `SDKMAN_DIR` to that path using your preferred method, or 
+   - add
+     ```fish
+     set -g __sdkman_custom_dir /your/path/to/sdkman
+     ```
+     to a fish config file
+       [run _before_](https://fishshell.com/docs/current/language.html#configuration-files)
+     `.config/fish/conf.d/sdk.fish`;
+     for example, you can use `.config/fish/conf.d/config_sdk.fish`.
+   - If _both_ are set, `__sdkman_custom_dir` is used.
 
 
 ## Usage

--- a/conf.d/sdk.fish
+++ b/conf.d/sdk.fish
@@ -10,21 +10,28 @@
 # Account for custom install locations
 if set -q __sdkman_custom_dir
     set -gx SDKMAN_DIR "$__sdkman_custom_dir"
-else
-    # This is the default location:
+end
+# Guard: SDKMAN! needs to be installed
+if set -q SDKMAN_DIR; and not test -f "$SDKMAN_DIR/bin/sdkman-init.sh"
+    echo "WARNING: SDKMAN! installation path set to $SDKMAN_DIR, but no installation found there"
+    exit 0
+end
+
+# Unless overridden, use the default location:
+if not set -q SDKMAN_DIR
     set -gx SDKMAN_DIR "$HOME/.sdkman"
 end
 
 set __fish_sdkman_init "$SDKMAN_DIR/bin/sdkman-init.sh"
 
-# Copied from https://github.com/jorgebucaran/fisher/blob/main/functions/fisher.fish to be consistent:
-set --query fisher_path || set --local fisher_path $__fish_config_dir
-set __fish_sdkman_noexport_init "$fisher_path/functions/__sdkman-noexport-init.sh"
-
 # Guard: SDKMAN! needs to be installed
 if not test -f "$__fish_sdkman_init"
     exit 0
 end
+
+# Copied from https://github.com/jorgebucaran/fisher/blob/main/functions/fisher.fish to be consistent:
+set --query fisher_path || set --local fisher_path $__fish_config_dir
+set __fish_sdkman_noexport_init "$fisher_path/functions/__sdkman-noexport-init.sh"
 
 # Hack for issue #19:
 # Create version of sdkman-init that doesn't export any environment variables.

--- a/test/features/corner_cases.feature
+++ b/test/features/corner_cases.feature
@@ -5,14 +5,18 @@ Feature: Corner Cases
         When  a new Fish shell is launched
         Then  environment variable SDKMAN_DIR has the original value
 
-    Scenario: sdk initialized for another user in this shell
-        # Use any directory outside of the user's home directory
-        Given environment variable SDKMAN_DIR is set to "/"
-        When  a new Fish shell is launched
-        Then  environment variable SDKMAN_DIR has the original value
-
-    Scenario: Custom installation path
+    Scenario: Custom installation path via env var
         Given SDKMAN! is installed at /tmp/sdkman
+        And   environment variable SDKMAN_DIR is set to "/tmp/sdkman"
+        When  we run "sdk version" in Fish
+        Then  the exit code is 0
+        And   the output contains "SDKMAN!"
+        And   environment variable SDKMAN_DIR has value "/tmp/sdkman"
+        And   environment variable ANT_HOME has value "/tmp/sdkman/candidates/ant/current"
+
+    Scenario: Custom installation path via fish config
+        Given SDKMAN! is installed at /tmp/sdkman
+        And   environment variable SDKMAN_DIR is set to "/something/wicked"
         And   fish config file config_sdk.fish exists with content
             """
             set -g __sdkman_custom_dir /tmp/sdkman
@@ -25,10 +29,7 @@ Feature: Corner Cases
 
     Scenario Outline: Completions with custom installation path
         Given SDKMAN! is installed at /tmp/sdkman
-        And   fish config file config_sdk.fish exists with content
-            """
-            set -g __sdkman_custom_dir /tmp/sdkman
-            """
+        And   environment variable SDKMAN_DIR is set to "/tmp/sdkman"
         When the user enters "<cmd>" into the prompt
         Then completion should propose "<completions>"
         Examples:

--- a/test/features/support/helpers.rb
+++ b/test/features/support/helpers.rb
@@ -64,10 +64,12 @@ def run_fish_command(cmd)
     end.to_h
 
     out, status = Open3.capture2e(<<~FISH
+      #{@command.nil? ? '' : @command}
       fish -c '#{cmd} > #{files[:stdout]} 2> #{files[:stderr]}; \
                echo $status > #{files[:status]}; \
                env > #{files[:env]}; \
               '
+      #{@command.nil? ? '' : ')'}
     FISH
     )
 


### PR DESCRIPTION
Also, print a warning during shell startup if a custom install path is set, but SDKMAN! is not installed there.

fixes #52