### PR TITLE
fix: direct rm(1) output to /dev/null to prevent custom wrappers from throwing errors

### DIFF
--- a/conf.d/sdk.fish
+++ b/conf.d/sdk.fish
@@ -62,7 +62,7 @@ function __fish_sdkman_run_in_bash
              env | grep -i -E \"^(`echo \${SDKMAN_CANDIDATES_CSV} | sed 's/,/|/g'`)_HOME\" >> $pipe;
              echo \"SDKMAN_OFFLINE_MODE=\${SDKMAN_OFFLINE_MODE}\" >> $pipe;
              echo \"SDKMAN_ENV=\${SDKMAN_ENV}\" >> $pipe" # it's not an environment variable!
-    set bashDump (cat $pipe; rm $pipe)
+    set bashDump (cat $pipe; rm $pipe >/dev/null)
 
     set sdkStatus $bashDump[1]
     set bashEnv $bashDump[2..-1]


### PR DESCRIPTION
I use a custom wrapper for `rm(1)` which gives me some more safety and explicitness when removing protected files and directories.
```fish
function rm --description 'a safer rm(1)'
    command rm --interactive=once --verbose $argv
end
```
because of the `--verbose` argument, however, this wrapper interacts badly with `sdk` because of a small detail in a single line which makes `fish` throw errors around:
<img width="1920" height="421" alt="terminal screenshot showing error messages from the set command in fish because of output from rm(1) being written to the pipe" src="https://github.com/user-attachments/assets/7db8e2fe-816b-477a-b4cc-b3fdf1e521b9" />

this pull request simply pipes the output of `rm(1)` to `/dev/null` to prevent such clutter.